### PR TITLE
As per new release note updated cli path

### DIFF
--- a/docs/_documentation/TypeScript-Add-ServiceStack-Reference.md
+++ b/docs/_documentation/TypeScript-Add-ServiceStack-Reference.md
@@ -105,7 +105,7 @@ The [servicestack-cli](https://github.com/ServiceStack/servicestack-cli) npm pac
 
 Prerequisites: Node.js (>=4.x, 6.x preferred), npm version 3+.
 
-    $ npm install -g servicestack-cli
+    $ npm install -g @servicestack/cli
 
 ### Adding a ServiceStack Reference
 


### PR DESCRIPTION
`npm i -g @servicestack/cli` will come instead of `npm i -g servicestack-cli`