### PR TITLE
Fix AuthService name in Authentication and Authorization doc

### DIFF
--- a/docs/_documentation/Authentication-and-authorization.md
+++ b/docs/_documentation/Authentication-and-authorization.md
@@ -326,7 +326,7 @@ By default the AuthFeature plugin automatically registers the following (overrid
 ```csharp
 new AuthFeature = {
   ServiceRoutes = new Dictionary<Type, string[]> {
-    { typeof(AuthService), new[]{"/auth", "/auth/{provider}"} },
+    { typeof(AuthenticateService), new[]{"/auth", "/auth/{provider}"} },
     { typeof(AssignRolesService), new[]{"/assignroles"} },
     { typeof(UnAssignRolesService), new[]{"/unassignroles"} },
   }


### PR DESCRIPTION
From AuthService to AuthenticateService

I was not able to find `AuthService` but `ServiceStack.Auth.AuthenticateService` looks like the correct name