### PR TITLE
Changed Digest Auth links to point to correct wikipedia article

### DIFF
--- a/docs/_documentation/Authentication-and-authorization.md
+++ b/docs/_documentation/Authentication-and-authorization.md
@@ -47,7 +47,7 @@ and authenticate against one of the following Auth Providers:
 |-|-|-|-|
 | **Credentials**   | `CredentialsAuthProvider`   | **/auth/credentials**    | Standard Authentication using Username/Password |
 | **Basic Auth**    | `BasicAuthProvider`         | HTTP Basic Auth          | Username/Password sent via [HTTP Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication) |
-| **Digest Auth**   | `DigestAuthProvider`        | HTTP Digest Auth         | Username/Password hash via [HTTP Digest Auth](https://en.wikipedia.org/wiki/Basic_access_authentication) |
+| **Digest Auth**   | `DigestAuthProvider`        | HTTP Digest Auth         | Username/Password hash via [HTTP Digest Auth](https://en.wikipedia.org/wiki/Digest_access_authentication) |
 {% endcapture %}
 {{ table | markdownify }}
 </div>

--- a/docs/_documentation/Security.md
+++ b/docs/_documentation/Security.md
@@ -38,7 +38,7 @@ and authenticate against one of the following Auth Providers:
 |-|-|-|-|
 | **Credentials**   | `CredentialsAuthProvider`   | **/auth/credentials**    | Standard Authentication using Username/Password |
 | **Basic Auth**    | `BasicAuthProvider`         | HTTP Basic Auth          | Username/Password sent via [HTTP Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication) |
-| **Digest Auth**   | `DigestAuthProvider`        | HTTP Digest Auth         | Username/Password hash via [HTTP Digest Auth](https://en.wikipedia.org/wiki/Basic_access_authentication) |
+| **Digest Auth**   | `DigestAuthProvider`        | HTTP Digest Auth         | Username/Password hash via [HTTP Digest Auth](https://en.wikipedia.org/wiki/Digest_access_authentication) |
 {% endcapture %}
 {{ table | markdownify }}
 </div>


### PR DESCRIPTION
There were two links for HTTP Digest Auth that pointed to a Wikipedia article on HTTP Basic Auth.  I updated these links to the Wikipedia article on HTTP Digest Authentication.  The link used was used in other spots on the same pages.