### PR TITLE
Fix relocated link to wwwlicious article

### DIFF
--- a/docs/_documentation/Service-Discovery.md
+++ b/docs/_documentation/Service-Discovery.md
@@ -107,4 +107,4 @@ additional aspects of a ServiceStack AppHost's internal state.
 
 # Community Resources
 
-  - [Service discovery, load balancing and routing](http://www.wwwlicious.com/2016/05/11/servicestack-microservices-discovery-routing-3/) by [@wwwlicious](https://twitter.com/wwwlicious)
+  - [Service discovery, load balancing and routing](https://www.wwwlicious.com/servicestack-microservices-discovery-routing-3/) by [@wwwlicious](https://twitter.com/wwwlicious)


### PR DESCRIPTION
Some shuffling around of content on wwwlicious warrants a change to the Community Resources link.