### PR TITLE
Updated Autofac Adapter

### DIFF
--- a/docs/_documentation/The-IoC-container.md
+++ b/docs/_documentation/The-IoC-container.md
@@ -317,14 +317,12 @@ public class AutofacIocAdapter : IContainerAdapter
 
     public T TryResolve<T>()
     {
-        T result;
+        if (container.TryResolve(typeof(T), out var result))
+	{
+	    return (T)result;
+	}
 
-        if (container.TryResolve<T>(out result))
-        {
-            return result;
-        }
-
-        return default(T);
+	return default;
     }
 }
 ```


### PR DESCRIPTION
Version 5.X introduced a constraint on its TryResolve<T> method.
Tested on Autofac 4.9.4 and 5.1.2