### PR TITLE
Need some advice how to achieve virgin first deploy

### DIFF
--- a/docs/litestream-templates.md
+++ b/docs/litestream-templates.md
@@ -50,6 +50,8 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     # Timeout of health check will need to depend on size of db, and speed of network to host.
     healthcheck:
+      # There is a first use test needed to ensure virgin first deploy succeeds.
+      # test /usr/local/bin/litestream version
       test: /usr/local/bin/litestream restore -if-db-not-exists -if-replica-exists -o /data/app.db s3://${AWS_S3_BUCKET}/MyApp.sqlite
       timeout: 10m
       retries: 1


### PR DESCRIPTION
I spent a few days figuring out why following all the steps in this article didn't work. The reason was the healthcheck for litestream always fails if no db exists and no replica exists, which is true for the first deployment. My workaround, which I don't think is something I'd advise to do, was to change the healthcheck test to 
  healthcheck:
      test: /usr/local/bin/litestream version
which will pass first use.
I don't assume that my approach is correct, in fact it kind of feels like a hack, which is why my comment is the true pull request, not the file change.