### PR TITLE
Delete useless code from documentation

### DIFF
--- a/docs/api-key-authprovider.md
+++ b/docs/api-key-authprovider.md
@@ -348,7 +348,6 @@ public class ConfigureAuth : IHostingStartup
                 .Where(x => userWithKeysIds.Count == 0 || !userWithKeysIds.Contains(x.Id))
                 .Select(x => x.Id));
 
-            var authRepo = (IManageApiKeys)appHost.TryResolve<IAuthRepository>();
             foreach (var userId in userIdsMissingKeys)
             {
                 var apiKeys = authProvider.GenerateNewApiKeys(userId);


### PR DESCRIPTION
"var authRepo = (IManageApiKeys)appHost.TryResolve<IAuthRepository>();" is never used.