### PR TITLE
renamed DTO to match result shown in image

### DIFF
--- a/docs/metadata-page.md
+++ b/docs/metadata-page.md
@@ -25,7 +25,7 @@ You can also optionally add custom annotations and documentation on services whi
 [Api("Service Description")]
 [Route("/swagger/{Name}", "GET", Summary = "GET Summary", Notes="Notes")]
 [Route("/swagger/{Name}", "POST", Summary ="POST Summary", Notes="Notes")]
-public class MyRequestDto
+public class SwaggerTest
 {
     [ApiMember(Name="Name", Description = "Name Description", 
         ParameterType = "path", DataType = "string", IsRequired = true)]


### PR DESCRIPTION
When I was reading the docs I got confused about how the Metadata attribute ApiAttribute worked based on the image shown.  I believe the DTO should have the name SwaggerTest in order to match the image here: https://raw.githubusercontent.com/ServiceStack/Assets/master/img/release-notes/metadata-swagger-api.png